### PR TITLE
Bump libui-node dep to 0.2.0-rc1

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "libui-node": "parro-it/libui-node#0_2_0"
+    "libui-node": "^0.2.0-rc1"
   },
   "devDependencies": {
     "now": "^11.1.7"


### PR DESCRIPTION
The tests works as expected:
```
Passed: area-adv.js - "libui textDrawArea Example"
Failed: text.js - "libui textDrawArea Example", see snapshots/temp/text.js_diff.png
Passed: forms.js - "Forms window"
Passed: grid.js - "Forms window"
Passed: node-pad.js - "Node Pad"
Generated HTML report: snapshots/index.html
```

published results to now:
https://snapshots-uyjcnzwcni.now.sh